### PR TITLE
Add Additional Tags to Module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,12 @@
 # Titan Layer Module
+
+locals {
+  resource_tags = merge(
+    {
+      titan_layer = var.name,
+      titan_network = var.network_name,
+      titan_zone = var.zone,
+    },
+    var.addtl_tags,
+  )
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,13 @@
 # Titan Layer Module - Outputs
 
+output addtl_tags {
+  value = var.addtl_tags
+
+  description = <<-EOF
+    Additional tags applied to resources.
+  EOF
+}
+
 output availability_zones {
   value = var.availability_zones
 
@@ -29,6 +37,14 @@ output network_name {
 
   description = <<-EOF
     The name of the Titan Network to which this layer belongs.
+  EOF
+}
+
+output resource_tags {
+  value = local.resource_tags
+
+  description = <<-EOF
+    Common tags associated with all resources.
   EOF
 }
 

--- a/r.network_acl.tf
+++ b/r.network_acl.tf
@@ -6,12 +6,7 @@ resource aws_network_acl default {
   subnet_ids = aws_subnet.default.*.id
 
   # tags
-  tags = {
-    Name = "${var.name}.${var.zone}"
-    titan_layer = var.name
-    titan_network = var.network_name
-    titan_zone = var.zone
-  }
+  tags = merge({ Name = "${var.name}.${var.zone}" }, local.resource_tags)
 }
 
 # Default Ingress Rule: Allow All (Override by Lower Priority Rule)

--- a/r.routing.tf
+++ b/r.routing.tf
@@ -7,12 +7,7 @@ resource aws_route_table default {
   vpc_id = var.vpc_id
 
   # tags
-  tags = {
-    Name = "${var.name}-${count.index}.${var.zone}"
-    titan_layer = var.name
-    titan_network = var.network_name
-    titan_zone = var.zone
-  }
+  tags = merge({ Name = "${var.name}-${count.index}.${var.zone}" }, local.resource_tags)
 }
 
 resource aws_route_table_association default {

--- a/r.subnet.tf
+++ b/r.subnet.tf
@@ -13,10 +13,5 @@ resource aws_subnet default {
   assign_ipv6_address_on_creation = true
 
   # tags
-  tags = {
-    Name = "${var.name}-${count.index}.${var.zone}"
-    titan_layer = var.name
-    titan_network = var.network_name
-    titan_zone = var.zone
-  }
+  tags = merge({ Name = "${var.name}-${count.index}.${var.zone}" }, local.resource_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,14 @@
 # Titan Layer Module - Variables
 
+variable addtl_tags {
+  type = map(string)
+  default = {}
+
+  description = <<-EOF
+    Additional tags to apply to resources.
+  EOF
+}
+
 variable availability_zones {
   type = list(string)
 


### PR DESCRIPTION
In its previous, propriatery implementation, additional tags were used to identify environments; our initial implementation here missed these, so we are adding them now.